### PR TITLE
fix(twelho): Match correct architecture on x86_64 systems

### DIFF
--- a/src/kcl.rs
+++ b/src/kcl.rs
@@ -45,8 +45,8 @@ impl KclExtension {
         // Get architecture name
         let arch_name = match arch {
             zed::Architecture::Aarch64 => "arm64",
-            zed::Architecture::X86 => "amd64",
-            zed::Architecture::X8664 =>
+            zed::Architecture::X8664 => "amd64",
+            zed::Architecture::X86 =>
                 return Err(format!("unsupported architecture: {arch:?}")),
         };
 


### PR DESCRIPTION
Hi, thanks for the great extension!

On `x86_64` (or `amd64`), the extension fails with an unsupported architecture error. This seems to be just a mistake involving `X8664` and `X86` being the wrong way around, since KCL doesn't ship 32-bit binaries.